### PR TITLE
Clear jobs if we try to fetch them and they aren't there

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -27,7 +27,11 @@ class Job extends Emitter {
           client.hget(queue.toKey('jobs'), jobId, done)
         )
       )
-      .then((data) => (data ? Job.fromData(queue, jobId, data) : null));
+      .then((data) =>
+        data
+          ? Job.fromData(queue, jobId, data)
+          : queue.removeJob(jobId).then(() => null)
+      );
 
     if (cb) helpers.asCallback(promise, cb);
     return promise;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -673,18 +673,18 @@ class Queue extends Emitter {
             return;
           }
 
-          this.running += 1;
-          this.queued -= 1;
-          if (this.running + this.queued < this.concurrency) {
-            this.queued += 1;
-            setImmediate(jobTick);
-          }
-
           if (!job) {
             // Per comment in Queue#_waitForJob, this branch is possible when
             // the job is removed before processing can take place, but after
             // being initially acquired.
             return;
+          }
+
+          this.running += 1;
+          this.queued -= 1;
+          if (this.running + this.queued < this.concurrency) {
+            this.queued += 1;
+            setImmediate(jobTick);
           }
 
           return this._runJob(job).then((results) => {

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1297,6 +1297,41 @@ describe('Queue', (it) => {
       t.is(err.message, `Job ${job.id} timed out (10 ms)`);
     });
 
+    it('clears a waiting job that is missing data', async (t) => {
+      const queue = t.context.makeQueue();
+
+      const job = await queue.createJob({foo: 'first'}).save();
+
+      // Delete the job's data from redis
+      await new Promise((resolve) =>
+        queue.client.hdel(queue.toKey('jobs'), job.id, resolve)
+      );
+
+      // Create a second job
+      await queue.createJob({foo: 'second'}).save();
+
+      const succeeded = helpers.waitOn(queue, 'succeeded');
+
+      // Now run the queue
+      let callCount = 0;
+      queue.process(async (processedJob) => {
+        callCount += 1;
+        t.is(processedJob.data.foo, 'second');
+      });
+
+      await succeeded;
+      t.is(callCount, 1);
+
+      // By default the job id would have been moved to the active list (soon to stall)
+      // So we just check it is no longer there
+      await new Promise((resolve) =>
+        queue.client.llen(queue.toKey('active'), (_, active) => {
+          t.is(active, 0);
+          resolve();
+        })
+      );
+    });
+
     it('processes a job that auto-retries', async (t) => {
       const queue = t.context.makeQueue();
       const retries = 1;


### PR DESCRIPTION
Sometimes jobs go missing from the `"jobs"` data structure. Although BQ handles this it doesn't clean them up.