### PR TITLE
Ensure we don't call `unpack` with too many elements

### DIFF
--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -1708,6 +1708,36 @@ describe('Queue', (it) => {
       return done;
     });
 
+    it('should reset and process more than the unpack limit stalled jobs when starting a queue', async (t) => {
+      t.plan(0);
+
+      const queue = t.context.makeQueue({
+        stallInterval: 1,
+      });
+
+      // Create 1025 jobs
+      const jobs = Array.from(new Array(1025)).map((_, i) =>
+        queue.createJob({foo: `bar${i}`})
+      );
+
+      // Save the jobs.
+      await Promise.all(jobs.map((job) => job.save()));
+
+      // Artificially move to active.
+      await queue._getNextJob();
+
+      // Mark the jobs as stalling, so that Queue#process immediately detects
+      // them as stalled.
+      await forceStall(queue);
+
+      const {done, next} = reef(jobs.length);
+      queue.process(async () => {
+        next();
+      });
+
+      return done;
+    });
+
     it('resets and processes jobs from multiple stalled queues', async (t) => {
       const queues = [];
       for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
`unpack` puts thing on Lua's stack, which has a limit based on how much memory it is allocated. In redis this seems to be about 8k items, tested by running:

```
eval "redis.call('ltrim', KEYS[1], 1, 0); local i, r = 0, {}; while (i < tonumber(ARGV[1])) do r[i] = i; i = i + 1; end; redis.call('lpush', KEYS[1], unpack(r)); return redis.call('llen', KEYS[1]);" 1 foo 9000
```

With various numbers at the end. I use 1024 here to be pretty conservative.